### PR TITLE
Update sudoku IO: reduce IO times

### DIFF
--- a/SudokuProject/main.cpp
+++ b/SudokuProject/main.cpp
@@ -31,9 +31,9 @@ int main(int argc, char *argv[]) {
     SudokuIOer sudokuIOer;
     // SudokuPrinter sudokuPrinter;
 
-    fstream sudokuFile;
+    ofstream sudokuFile("sudoku.txt", ios::out | ios::ate);
     // open sudoku.txt 
-    sudokuFile.open(filename, ios::app);
+    // sudokuFile.open("sudoku.txt", ios::app);
 
     bool signal = false;
 

--- a/SudokuProject/main.cpp
+++ b/SudokuProject/main.cpp
@@ -4,6 +4,7 @@
 #include "sudokuIO.h"
 #include "sudokuExceptionInspector.h"
 #include <stdlib.h>
+#include <fstream>
 // #include <unistd.h>
 #include <iostream>
 using namespace std;
@@ -30,18 +31,25 @@ int main(int argc, char *argv[]) {
     SudokuIOer sudokuIOer;
     // SudokuPrinter sudokuPrinter;
 
+    fstream sudokuFile;
+    // open sudoku.txt 
+    sudokuFile.open(filename, ios::app);
+
     bool signal = false;
 
     for (int i = 0; i < solutionNumber; i++) {
         signal = sudokuGenerator.Generator();
         if (signal) {
             sudokuGenerator.increaseRandomSeed();
-            sudokuIOer.outputFile(sudokuGenerator.solution, "sudoku.txt");
+            sudokuIOer.outputFile(sudokuGenerator.solution, sudokuFile);
         } else {
             cout << "Error occurs when applying sudokuGenerator." << endl;
             return 1;
         }
     }
+
+    // close sudoku.txt
+    sudokuFile.close();
 
     return 0;
 }

--- a/SudokuProject/sudokuIO.cpp
+++ b/SudokuProject/sudokuIO.cpp
@@ -1,9 +1,10 @@
 #include "sudokuIO.h"
 #include <stdlib.h>
+#include <fstream>
 #include <iostream>
 using namespace std;
 
-void SudokuIOer::outputFile(int solution[9][9], fstream sudokuFile) {
+void SudokuIOer::outputFile(int solution[9][9], ofstream& sudokuFile) {
     int i, j;
     for (i = 0; i < 9; i++) {
         for (j = 0; j < 9; j++) {

--- a/SudokuProject/sudokuIO.cpp
+++ b/SudokuProject/sudokuIO.cpp
@@ -1,15 +1,9 @@
 #include "sudokuIO.h"
-#include <fstream>
 #include <stdlib.h>
 #include <iostream>
 using namespace std;
 
-void SudokuIOer::outputFile(int solution[9][9], char filename[]) {
-    fstream sudokuFile;
-    // open sudoku.txt 
-    sudokuFile.open(filename, ios::app);
-
-    // write the answer to sudoku.txt
+void SudokuIOer::outputFile(int solution[9][9], fstream sudokuFile) {
     int i, j;
     for (i = 0; i < 9; i++) {
         for (j = 0; j < 9; j++) {
@@ -21,7 +15,4 @@ void SudokuIOer::outputFile(int solution[9][9], char filename[]) {
         }
     }
     sudokuFile << "\n";
-
-    // close sudoku.txt
-    sudokuFile.close();
 }

--- a/SudokuProject/sudokuIO.h
+++ b/SudokuProject/sudokuIO.h
@@ -1,14 +1,14 @@
 #ifndef IOER_H
 #define IOER_H
-#include <iostream>
 #include <fstream>
+#include <iostream>
 using namespace std;
 
 class SudokuIOer {
 public:
     SudokuIOer() {
     }
-    void outputFile(int solution[9][9], fstream sudokuFile);
+    void outputFile(int solution[9][9], ofstream& sudokuFile);
 };
 
 #endif

--- a/SudokuProject/sudokuIO.h
+++ b/SudokuProject/sudokuIO.h
@@ -1,13 +1,14 @@
 #ifndef IOER_H
 #define IOER_H
 #include <iostream>
+#include <fstream>
 using namespace std;
 
 class SudokuIOer {
 public:
     SudokuIOer() {
     }
-    void outputFile(int solution[9][9], char filename[]);
+    void outputFile(int solution[9][9], fstream sudokuFile);
 };
 
 #endif


### PR DESCRIPTION
Open sudoku.txt before 'for' looping, in order to reduce the performance overhead.